### PR TITLE
Add workflow filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,9 +147,13 @@ workflows:
             tags:
               only:
                 - /test\/.*/
+            branches:
+              ignore: /.*/
       - showinfo:
           title: tag-ignore-test
           filters:
             tags:
               ignore:
                 - /test\/.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ workflows:
       - job_restore_workspace:
           requires:
             - job_store_workspace
+  # featureブランチのときだけrun-approvalがでて、依存するshowinfoが実行まちになる
   approve-only-feature:
     jobs:
       - run-approval:
@@ -118,6 +119,7 @@ workflows:
       - showinfo:
           requires:
             - run-approval
+  # featureブランチのときにはこのworkflow自体が消える
   approve-ignore-feature:
     jobs:
       - run-approval:
@@ -129,6 +131,7 @@ workflows:
       - showinfo:
           requires:
             - run-approval
+  # featureか否かでどちらかのjobだけが実行される
   branch-filter-feature:
     jobs:
       - showinfo:
@@ -143,6 +146,8 @@ workflows:
             branches:
               ignore:
                 - /feature\/.*/
+  # tagが付いてるコミットの場合でだけ実行される
+  # デフォルトの場合push時にはtag付与がないので実行されることはない
   tag-filter-feature:
     jobs:
       - showinfo:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,9 @@ workflows:
             branches:
               only:
                 - /feature\/.*/
-      - showinfo
+      - showinfo:
+          requires:
+            - run-approval
   approve-ignore-feature:
     jobs:
       - run-approval:
@@ -124,7 +126,9 @@ workflows:
             branches:
               ignore:
                 - /feature\/.*/
-      - showinfo
+      - showinfo:
+          requires:
+            - run-approval
   branch-filter-feature:
     jobs:
       - showinfo:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,13 @@ commands:
 jobs:
   showinfo:
     executor: default
+    parameters:
+      title:
+        type: string
+        default: showinfo
     steps:
       - checkout
-      - run: echo "This job is << pipeline.id >> $CIRCLE_JOB"
+      - run: echo "This job [<< parameters.title >>] at << pipeline.id >> $CIRCLE_JOB"
   job_store_cache_in_workflow:
     executor: default
     steps:
@@ -103,6 +107,15 @@ workflows:
       - job_restore_workspace:
           requires:
             - job_store_workspace
+  approve-only-feature:
+    jobs:
+      - run-approval:
+          type: approval
+          filters:
+            branches:
+              only:
+                - /feature\/.*/
+      - showinfo
   approve-ignore-feature:
     jobs:
       - run-approval:
@@ -115,14 +128,28 @@ workflows:
   branch-filter-feature:
     jobs:
       - showinfo:
+          title: branch-only-feature
           filters:
             branches:
               only:
                 - /feature\/.*/
+      - showinfo:
+          title: branch-ignore-feature
+          filters:
+            branches:
+              ignore:
+                - /feature\/.*/
   tag-filter-feature:
     jobs:
       - showinfo:
+          title: tag-only-test
           filters:
             tags:
               only:
+                - /test\/.*/
+      - showinfo:
+          title: tag-ignore-test
+          filters:
+            tags:
+              ignore:
                 - /test\/.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,3 +103,26 @@ workflows:
       - job_restore_workspace:
           requires:
             - job_store_workspace
+  approve-ignore-feature:
+    jobs:
+      - run-approval:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - /feature\/.*/
+      - showinfo
+  branch-filter-feature:
+    jobs:
+      - showinfo:
+          filters:
+            branches:
+              only:
+                - /feature\/.*/
+  tag-filter-feature:
+    jobs:
+      - showinfo:
+          filters:
+            tags:
+              only:
+                - /test\/.*/


### PR DESCRIPTION
- branchフィルターは機能する
- tagは付与するタイミングとpushのタイミングが異なるのでschedule起動などの方が良さそう
- jobにパラメータ指定が出来る
- 依存関係の1つがフィルターされると後ろのジョブも全て消える
